### PR TITLE
Nitpick typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Create an `.eslintrc` file and add this config to the `extends` section
 Since adding new rules or modifying existing rules might break builds, such changes should result in a major version bump.
 
 
-Handcrafted with ♥ at Redmart.
+Handcrafted with ❤️ at RedMart.


### PR DESCRIPTION
Camel case seems to be canonical. Also using the unicode heart emoji instead of black heart suit glyph.